### PR TITLE
cmd/bootnode, p2p: use an alternate port mapped to NAT

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -143,11 +143,9 @@ func main() {
 						log.Debug("Couldn't add port mapping", "err", err)
 					}
 					if p != uint16(external) {
-						// #1
-						realaddr.Port = int(p)
-						printNotice(&nodeKey.PublicKey, *realaddr)
-
-						// #2
+						// If the port mapping is changed after the boot node is executed and the
+						// url is shared, there is no point in continuing the node. In this case,
+						// re-execute with an available port and share the url again.
 						natm.DeleteMapping(protocol, int(p), internal)
 						panic(fmt.Errorf("port %d already mapped to another address (hint: use %d", external, p))
 					}

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -128,9 +128,11 @@ func main() {
 			if p == uint16(external) {
 				log.Info("Mapped network port")
 			} else {
-				log.Debug("Already used port by another peers", external, "use alternative port", p)
+				log.Debug("Already mapped port by another peers", external, "use alternative port", p)
 				external = int(p)
 				realaddr.Port = external
+
+				log = log.New("proto", protocol, "extport", external, "intport", internal, "interface", natm)
 			}
 
 			go func() {
@@ -144,8 +146,8 @@ func main() {
 					}
 					if p != uint16(external) {
 						// If the port mapping is changed after the boot node is executed and the
-						// url is shared, there is no point in continuing the node. In this case,
-						// re-execute with an available port and share the url again.
+						// URL is shared, there is no point in continuing the node. In this case,
+						// re-execute with an available port and share the URL again.
 						natm.DeleteMapping(protocol, int(p), internal)
 						panic(fmt.Errorf("port %d already mapped to another address (hint: use %d", external, p))
 					}

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -146,13 +146,14 @@ func main() {
 					p, err := natm.AddMapping(protocol, extport, intport, name, mapTimeout)
 					if err != nil {
 						log.Debug("Couldn't add port mapping", "err", err)
-					}
-					if p != uint16(extport) {
-						// If the port mapping is changed after the boot node is executed and the
-						// URL is shared, there is no point in continuing the node. In this case,
-						// re-execute with an available port and share the URL again.
-						natm.DeleteMapping(protocol, int(p), intport)
-						panic(fmt.Errorf("port %d already mapped to another address (hint: use %d", extport, p))
+					} else {
+						if p != uint16(extport) {
+							// If the port mapping is changed after the boot node is executed and the
+							// URL is shared, there is no point in continuing the node. In this case,
+							// re-execute with an available port and share the URL again.
+							natm.DeleteMapping(protocol, int(p), intport)
+							panic(fmt.Errorf("port %d already mapped to another address (hint: use %d", extport, p))
+						}
 					}
 					refresh.Reset(mapTimeout)
 				}

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -132,8 +132,8 @@ func main() {
 			} else {
 				log.Info("Mapped network port")
 				if p != uint16(extport) {
-					log = newLogger(protocol, int(p), intport, natm)
 					log.Debug("Already mapped port", extport, "use alternative port", p)
+					log = newLogger(protocol, int(p), intport, natm)
 					extport = int(p)
 				}
 			}

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -129,13 +129,13 @@ func main() {
 			p, err := natm.AddMapping(protocol, extport, intport, name, mapTimeout)
 			if err != nil {
 				log.Debug("Couldn't add port mapping", "err", err)
-			}
-			if p == uint16(extport) {
-				log.Info("Mapped network port")
 			} else {
-				log = newLogger(protocol, int(p), intport, natm)
-				log.Debug("Already mapped port", extport, "use alternative port", p)
-				extport = int(p)
+				log.Info("Mapped network port")
+				if p != uint16(extport) {
+					log = newLogger(protocol, int(p), intport, natm)
+					log.Debug("Already mapped port", extport, "use alternative port", p)
+					extport = int(p)
+				}
 			}
 
 			go func() {

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -112,6 +112,12 @@ func main() {
 	if natm != nil {
 		if !realaddr.IP.IsLoopback() {
 			go nat.Map(natm, nil, "udp", realaddr.Port, realaddr.Port, "ethereum discovery")
+			go func() {
+				for p := range natm.AlternativePort() {
+					natm.DeleteMapping("udp", int(p), realaddr.Port)
+					panic(fmt.Errorf("port %d already mapped to another address", realaddr.Port))
+				}
+			}()
 		}
 		if ext, err := natm.ExternalIP(); err == nil {
 			realaddr = &net.UDPAddr{IP: ext, Port: realaddr.Port}

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -142,7 +142,7 @@ func main() {
 				refresh := time.NewTimer(mapTimeout)
 				for {
 					<-refresh.C
-					log.Trace("Refreshing port mapping")
+					log.Trace("Start port mapping")
 					p, err := natm.AddMapping(protocol, extport, intport, name, mapTimeout)
 					if err != nil {
 						log.Debug("Couldn't add port mapping", "err", err)

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -97,16 +97,14 @@ const (
 // Map adds a port mapping on m and keeps it alive until c is closed.
 // This function is typically invoked in its own goroutine.
 func Map(m Interface, c <-chan struct{}, protocol string, extport, intport int, name string) {
-	mapTimeout := DefaultMapTimeout
-
 	log := log.New("proto", protocol, "extport", extport, "intport", intport, "interface", m)
-	refresh := time.NewTimer(mapTimeout)
+	refresh := time.NewTimer(DefaultMapTimeout)
 	defer func() {
 		refresh.Stop()
 		log.Debug("Deleting port mapping")
 		m.DeleteMapping(protocol, extport, intport)
 	}()
-	if _, err := m.AddMapping(protocol, extport, intport, name, mapTimeout); err != nil {
+	if _, err := m.AddMapping(protocol, extport, intport, name, DefaultMapTimeout); err != nil {
 		log.Debug("Couldn't add port mapping", "err", err)
 	} else {
 		log.Info("Mapped network port")
@@ -119,10 +117,10 @@ func Map(m Interface, c <-chan struct{}, protocol string, extport, intport int, 
 			}
 		case <-refresh.C:
 			log.Trace("Refreshing port mapping")
-			if _, err := m.AddMapping(protocol, extport, intport, name, mapTimeout); err != nil {
+			if _, err := m.AddMapping(protocol, extport, intport, name, DefaultMapTimeout); err != nil {
 				log.Debug("Couldn't add port mapping", "err", err)
 			}
-			refresh.Reset(mapTimeout)
+			refresh.Reset(DefaultMapTimeout)
 		}
 	}
 }

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -92,12 +92,13 @@ func Parse(spec string) (Interface, error) {
 
 const (
 	DefaultMapTimeout = 10 * time.Minute
-	mapTimeout        = 10 * time.Minute
 )
 
 // Map adds a port mapping on m and keeps it alive until c is closed.
 // This function is typically invoked in its own goroutine.
 func Map(m Interface, c <-chan struct{}, protocol string, extport, intport int, name string) {
+	mapTimeout := DefaultMapTimeout
+
 	log := log.New("proto", protocol, "extport", extport, "intport", intport, "interface", m)
 	refresh := time.NewTimer(mapTimeout)
 	defer func() {

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -168,7 +168,7 @@ func UPnP() Interface {
 // address is nil, PMP will attempt to auto-discover the router.
 func PMP(gateway net.IP) Interface {
 	if gateway != nil {
-		return &pmp{gw: gateway, c: natpmp.NewClient(gateway), portchanged: make(chan uint16, 2)}
+		return &pmp{gw: gateway, c: natpmp.NewClient(gateway)}
 	}
 	return startautodisc("NAT-PMP", discoverPMP)
 }

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -55,11 +55,12 @@ func (n *pmp) AddMapping(protocol string, extport, intport int, name string, lif
 		return 0, err
 	}
 
-	// NAT-PMP maps an alternative available port number if the requested
-	// port is already mapped to another address and returns success.
+	// NAT-PMP maps an alternative available port number if the requested port
+	// is already mapped to another address and returns success. Handling of
+	// alternate port numbers is done by the caller.
 	//
-	// The result of AddPortMapping has several fields, but returns only
-	// MappedExternalPort(there are no cases where other fields are used).
+	// note: The result of AddPortMapping has several fields, but returns only
+	// MappedExternalPort(no other fields are used).
 	return res.MappedExternalPort, nil
 }
 

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -30,11 +30,6 @@ import (
 type pmp struct {
 	gw net.IP
 	c  *natpmp.Client
-
-	// NAT-PMP's AddPortMapping result has many fields, not just mapped ports.
-	// However, there is no case where those field values are used yet, and if
-	// they occur later, channels will be added.
-	portchanged chan uint16
 }
 
 func (n *pmp) String() string {
@@ -73,10 +68,6 @@ func (n *pmp) DeleteMapping(protocol string, extport, intport int) (err error) {
 	return err
 }
 
-func (n *pmp) AlternativePort() chan uint16 {
-	return n.portchanged
-}
-
 func discoverPMP() Interface {
 	// run external address lookups on all potential gateways
 	gws := potentialGateways()
@@ -88,7 +79,7 @@ func discoverPMP() Interface {
 			if _, err := c.GetExternalAddress(); err != nil {
 				found <- nil
 			} else {
-				found <- &pmp{gw, c, make(chan uint16, 2)}
+				found <- &pmp{gw, c}
 			}
 		}()
 	}

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -57,6 +57,9 @@ func (n *pmp) AddMapping(protocol string, extport, intport int, name string, lif
 
 	// NAT-PMP maps an alternative available port number if the requested
 	// port is already mapped to another address and returns success.
+	//
+	// The result of AddPortMapping has several fields, but returns only
+	// MappedExternalPort(there are no cases where other fields are used).
 	return res.MappedExternalPort, nil
 }
 

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -76,16 +76,16 @@ func (n *upnp) ExternalIP() (addr net.IP, err error) {
 	return ip, nil
 }
 
-func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, lifetime time.Duration) error {
+func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, lifetime time.Duration) (uint16, error) {
 	ip, err := n.internalAddress()
 	if err != nil {
-		return nil // TODO: Shouldn't we return the error?
+		return 0, nil // TODO: Shouldn't we return the error?
 	}
 	protocol = strings.ToUpper(protocol)
 	lifetimeS := uint32(lifetime / time.Second)
 	n.DeleteMapping(protocol, extport, intport)
 
-	return n.withRateLimit(func() error {
+	return uint16(extport), n.withRateLimit(func() error {
 		return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
 	})
 }

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -119,6 +119,12 @@ func (n *upnp) DeleteMapping(protocol string, extport, intport int) error {
 	})
 }
 
+// UPnP simply returns an error if the requested port is
+// already in use, so here is no port change.
+func (n *upnp) AlternativePort() chan uint16 {
+	return nil
+}
+
 func (n *upnp) String() string {
 	return "UPNP " + n.service
 }

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -119,12 +119,6 @@ func (n *upnp) DeleteMapping(protocol string, extport, intport int) error {
 	})
 }
 
-// UPnP simply returns an error if the requested port is
-// already in use, so here is no port change.
-func (n *upnp) AlternativePort() chan uint16 {
-	return nil
-}
-
 func (n *upnp) String() string {
 	return "UPNP " + n.service
 }

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -85,11 +85,15 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 	lifetimeS := uint32(lifetime / time.Second)
 	n.DeleteMapping(protocol, extport, intport)
 
-	// UPnP simply returns an error if the requested port is already in use.
-	// Returns the requested port because no alternate port occurs.
-	return uint16(extport), n.withRateLimit(func() error {
+	err = n.withRateLimit(func() error {
 		return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
 	})
+	if err != nil {
+		return 0, err
+	}
+	// UPnP simply returns an error if the requested port is already in use.
+	// Returns the requested port because no alternate port occurs.
+	return uint16(extport), nil
 }
 
 func (n *upnp) internalAddress() (net.IP, error) {

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -85,6 +85,8 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 	lifetimeS := uint32(lifetime / time.Second)
 	n.DeleteMapping(protocol, extport, intport)
 
+	// UPnP simply returns an error if the requested port is already in use.
+	// Returns the requested port because no alternate port occurs.
 	return uint16(extport), n.withRateLimit(func() error {
 		return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
 	})

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -713,8 +713,8 @@ func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extp
 	} else {
 		log.Info("Mapped network port")
 		if p != uint16(external) {
-			log = newLogger(protocol, int(p), internal, natm)
 			log.Debug("Already mapped port", extport, "use alternative port", p)
+			log = newLogger(protocol, int(p), internal, natm)
 			external = int(p)
 		}
 		// Set it directly because it is an operation that is performed
@@ -747,8 +747,8 @@ func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extp
 				log.Debug("Couldn't add port mapping", "err", err)
 			} else {
 				if p != uint16(external) {
-					log = newLogger(protocol, int(p), internal, natm)
 					log.Debug("Already mapped port", external, "use alternative port", p)
+					log = newLogger(protocol, int(p), internal, natm)
 					external = int(p)
 
 					if err := srv.changePort(protocol, uint16(external)); err != nil {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -575,7 +575,6 @@ func (srv *Server) setupDiscovery() error {
 	srv.log.Debug("UDP listener up", "addr", realaddr)
 	if srv.NAT != nil {
 		if !realaddr.IP.IsLoopback() {
-			//
 			intport, extport := realaddr.Port, realaddr.Port
 			p, err := srv.NAT.AddMapping("udp", intport, extport, "", nat.DefaultMapTimeout)
 			if err != nil {
@@ -691,7 +690,8 @@ func (srv *Server) setupListening() error {
 	srv.ListenAddr = listener.Addr().String()
 
 	// Update the local node record and map the TCP listening port if NAT is configured.
-	if tcp, ok := listener.Addr().(*net.TCPAddr); ok {
+	tcp, ok := listener.Addr().(*net.TCPAddr)
+	if ok && srv.NAT != nil {
 		intport, extport := tcp.Port, tcp.Port
 		p, err := srv.NAT.AddMapping("tcp", intport, extport, "", nat.DefaultMapTimeout)
 		if err != nil {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -581,6 +581,9 @@ func (srv *Server) setupDiscovery() error {
 			// [NEED TO REMOVE] In this case, if the NAT doesn't respond, it will block for
 			// a long time. Have to decide whether we want to do the rest after the mapping,
 			// or run the goroutine and do the work first.
+			//
+			// Currently, it is not possible to distinguish whether the log is about for
+			// 'ethereum p2p' or 'ethereum discovery'.
 			p, err := srv.NAT.AddMapping("udp", intport, extport, "", nat.DefaultMapTimeout)
 			if err != nil {
 				srv.log.Debug("Couldn't add port mapping", "err", err)
@@ -701,6 +704,9 @@ func (srv *Server) setupListening() error {
 			// [NEED TO REMOVE] In this case, if the NAT doesn't respond, it will block for
 			// a long time. Have to decide whether we want to do the rest after the mapping,
 			// or run the goroutine and do the work first.
+			//
+			// Currently, it is not possible to distinguish whether the log is about for
+			// 'ethereum p2p' or 'ethereum discovery'.
 			p, err := srv.NAT.AddMapping("tcp", intport, extport, "", nat.DefaultMapTimeout)
 			if err != nil {
 				srv.log.Debug("Couldn't add port mapping", "err", err)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -707,7 +707,7 @@ func (srv *Server) natMapLoop(natm nat.Interface, protocol string, intport, extp
 	log := newLogger(protocol, external, internal, natm)
 
 	// Set to 0 to perform initial port mapping. It is set to
-	// mapTimeout in the next selection.
+	// mapTimeout in the next loop.
 	refresh := time.NewTimer(time.Duration(0))
 	defer func() {
 		refresh.Stop()

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -694,8 +694,7 @@ func (srv *Server) setupListening() error {
 	srv.ListenAddr = listener.Addr().String()
 
 	// Update the local node record and map the TCP listening port if NAT is configured.
-	tcp, ok := listener.Addr().(*net.TCPAddr)
-	if ok {
+	if tcp, ok := listener.Addr().(*net.TCPAddr); ok {
 		intport, extport := tcp.Port, tcp.Port
 		if !tcp.IP.IsLoopback() && srv.NAT != nil {
 			srv.log.Info("Start Adding Maps to NAT")

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -191,7 +191,7 @@ type Server struct {
 
 	// Channels into the run loop.
 	quit                    chan struct{}
-	changedport             chan enr.Entry
+	changeport              chan enr.Entry
 	addtrusted              chan *enode.Node
 	removetrusted           chan *enode.Node
 	peerOp                  chan peerOpFunc
@@ -467,7 +467,7 @@ func (srv *Server) Start() (err error) {
 		srv.listenFunc = net.Listen
 	}
 	srv.quit = make(chan struct{})
-	srv.changedport = make(chan enr.Entry)
+	srv.changeport = make(chan enr.Entry)
 	srv.delpeer = make(chan peerDrop)
 	srv.checkpointPostHandshake = make(chan *conn)
 	srv.checkpointAddPeer = make(chan *conn)
@@ -739,9 +739,9 @@ func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extp
 
 					switch protocol {
 					case "tcp":
-						srv.changedport <- enr.TCP(external)
+						srv.changeport <- enr.TCP(external)
 					case "udp":
-						srv.changedport <- enr.UDP(external)
+						srv.changeport <- enr.UDP(external)
 					}
 				}
 				refresh.Reset(mapTimeout)
@@ -785,7 +785,7 @@ running:
 			// The server was stopped. Run the cleanup logic.
 			break running
 
-		case entry := <-srv.changedport:
+		case entry := <-srv.changeport:
 			srv.localnode.Set(entry)
 
 		case n := <-srv.addtrusted:

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -574,12 +574,11 @@ func (srv *Server) setupDiscovery() error {
 	realaddr := conn.LocalAddr().(*net.UDPAddr)
 	srv.log.Debug("UDP listener up", "addr", realaddr)
 
-	intport, extport := realaddr.Port, realaddr.Port
 	if srv.NAT != nil {
 		if !realaddr.IP.IsLoopback() {
 			srv.loopWG.Add(1)
 			go func() {
-				srv.natRefresh(srv.NAT, "udp", intport, extport, "ethereum discovery", nat.DefaultMapTimeout)
+				srv.natRefresh(srv.NAT, "udp", realaddr.Port, realaddr.Port, "ethereum discovery", nat.DefaultMapTimeout)
 				srv.loopWG.Done()
 			}()
 		}
@@ -681,11 +680,10 @@ func (srv *Server) setupListening() error {
 
 	// Update the local node record and map the TCP listening port if NAT is configured.
 	if tcp, ok := listener.Addr().(*net.TCPAddr); ok {
-		intport, extport := tcp.Port, tcp.Port
 		if !tcp.IP.IsLoopback() && srv.NAT != nil {
 			srv.loopWG.Add(1)
 			go func() {
-				srv.natRefresh(srv.NAT, "tcp", intport, extport, "ethereum p2p", nat.DefaultMapTimeout)
+				srv.natRefresh(srv.NAT, "tcp", tcp.Port, tcp.Port, "ethereum p2p", nat.DefaultMapTimeout)
 				srv.loopWG.Done()
 			}()
 		}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -578,7 +578,7 @@ func (srv *Server) setupDiscovery() error {
 		if !realaddr.IP.IsLoopback() {
 			srv.loopWG.Add(1)
 			go func() {
-				srv.natRefresh(srv.NAT, "udp", realaddr.Port, realaddr.Port, "ethereum discovery", nat.DefaultMapTimeout)
+				srv.natMapLoop(srv.NAT, "udp", realaddr.Port, realaddr.Port, "ethereum discovery", nat.DefaultMapTimeout)
 				srv.loopWG.Done()
 			}()
 		}
@@ -683,7 +683,7 @@ func (srv *Server) setupListening() error {
 		if !tcp.IP.IsLoopback() && srv.NAT != nil {
 			srv.loopWG.Add(1)
 			go func() {
-				srv.natRefresh(srv.NAT, "tcp", tcp.Port, tcp.Port, "ethereum p2p", nat.DefaultMapTimeout)
+				srv.natMapLoop(srv.NAT, "tcp", tcp.Port, tcp.Port, "ethereum p2p", nat.DefaultMapTimeout)
 				srv.loopWG.Done()
 			}()
 		}
@@ -694,7 +694,8 @@ func (srv *Server) setupListening() error {
 	return nil
 }
 
-func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extport int, name string, interval time.Duration) {
+// natMapLoop performs initialization mapping for nat and repeats refresh.
+func (srv *Server) natMapLoop(natm nat.Interface, protocol string, intport, extport int, name string, interval time.Duration) {
 	var (
 		internal   = intport
 		external   = extport

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -583,7 +583,7 @@ func (srv *Server) setupDiscovery() error {
 		if !realaddr.IP.IsLoopback() {
 			srv.loopWG.Add(1)
 			go func() {
-				srv.natRefresh(srv.NAT, "udp", realaddr.Port, realaddr.Port, "ethereum discovery")
+				srv.natRefresh(srv.NAT, "udp", realaddr.Port, realaddr.Port, "ethereum discovery", nat.DefaultMapTimeout)
 				srv.loopWG.Done()
 			}()
 		}
@@ -700,7 +700,7 @@ func (srv *Server) setupListening() error {
 		if !tcp.IP.IsLoopback() && srv.NAT != nil {
 			srv.loopWG.Add(1)
 			go func() {
-				srv.natRefresh(srv.NAT, "tcp", intport, extport, "ethereum p2p")
+				srv.natRefresh(srv.NAT, "tcp", intport, extport, "ethereum p2p", nat.DefaultMapTimeout)
 				srv.loopWG.Done()
 			}()
 		}
@@ -711,11 +711,11 @@ func (srv *Server) setupListening() error {
 	return nil
 }
 
-func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extport int, name string) {
+func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extport int, name string, interval time.Duration) {
 	var (
 		internal   = intport
 		external   = extport
-		mapTimeout = nat.DefaultMapTimeout
+		mapTimeout = interval
 	)
 	log := log.New("proto", protocol, "extport", external, "intport", internal, "interface", natm)
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -707,7 +707,7 @@ func (srv *Server) natMapLoop(natm nat.Interface, protocol string, intport, extp
 	log := newLogger(protocol, external, internal, natm)
 
 	// Set to 0 to perform initial port mapping. It is set to
-	// interval in the next selection.
+	// mapTimeout in the next selection.
 	refresh := time.NewTimer(time.Duration(0))
 	defer func() {
 		refresh.Stop()

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -700,12 +700,12 @@ func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extp
 		external   = extport
 		mapTimeout = interval
 
-		refreshLogger = func(p string, e int, i int, n nat.Interface) log.Logger {
+		newLogger = func(p string, e int, i int, n nat.Interface) log.Logger {
 			return log.New("proto", p, "extport", e, "intport", i, "interface", n)
 		}
 	)
 
-	log := refreshLogger(protocol, external, internal, natm)
+	log := newLogger(protocol, external, internal, natm)
 
 	p, err := srv.NAT.AddMapping(protocol, intport, extport, name, mapTimeout)
 	if err != nil {
@@ -713,7 +713,7 @@ func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extp
 	} else {
 		log.Info("Mapped network port")
 		if p != uint16(external) {
-			log = refreshLogger(protocol, int(p), internal, natm)
+			log = newLogger(protocol, int(p), internal, natm)
 			log.Debug("Already mapped port", extport, "use alternative port", p)
 			external = int(p)
 		}
@@ -747,7 +747,7 @@ func (srv *Server) natRefresh(natm nat.Interface, protocol string, intport, extp
 				log.Debug("Couldn't add port mapping", "err", err)
 			} else {
 				if p != uint16(external) {
-					log = refreshLogger(protocol, int(p), internal, natm)
+					log = newLogger(protocol, int(p), internal, natm)
 					log.Debug("Already mapped port", external, "use alternative port", p)
 					external = int(p)
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -692,8 +692,8 @@ func (srv *Server) setupListening() error {
 
 	// Update the local node record and map the TCP listening port if NAT is configured.
 	tcp, ok := listener.Addr().(*net.TCPAddr)
-	intport, extport := tcp.Port, tcp.Port
 	if ok {
+		intport, extport := tcp.Port, tcp.Port
 		if !tcp.IP.IsLoopback() && srv.NAT != nil {
 			p, err := srv.NAT.AddMapping("tcp", intport, extport, "", nat.DefaultMapTimeout)
 			if err != nil {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -706,8 +706,8 @@ func (srv *Server) natMapLoop(natm nat.Interface, protocol string, intport, extp
 
 	log := newLogger(protocol, external, internal, natm)
 
-	// Set to 0 to perform initial port mapping. It is set to
-	// mapTimeout in the next loop.
+	// Set to 0 to perform initial port mapping. This will return C
+	// immediately and set it to mapTimeout in the next loop.
 	refresh := time.NewTimer(time.Duration(0))
 	defer func() {
 		refresh.Stop()

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -203,36 +203,6 @@ func TestServerDial(t *testing.T) {
 	}
 }
 
-func TestServerChangePort(t *testing.T) {
-	// run a one-shot TCP server to handle the connection.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("could not setup listener: %v", err)
-	}
-	defer listener.Close()
-
-	// start the server
-	connected := make(chan *Peer)
-	remid := &newkey().PublicKey
-	srv := startTestServer(t, remid, func(p *Peer) { connected <- p })
-	defer close(connected)
-	defer srv.Stop()
-
-	srv.changeport <- enr.TCP(12819)
-	time.Sleep(10 * time.Millisecond)
-	if srv.Self().TCP() != 12819 {
-		t.Fatalf("invalid port number, want: %v, got: %v\n", 12819, srv.Self().TCP())
-		return
-	}
-
-	srv.changeport <- enr.UDP(13819)
-	time.Sleep(10 * time.Millisecond)
-	if srv.Self().UDP() != 13819 {
-		t.Fatalf("invalid port number, want: %v, got: %v\n", 13819, srv.Self().UDP())
-		return
-	}
-}
-
 // This test checks that RemovePeer disconnects the peer if it is connected.
 func TestServerRemovePeerDisconnect(t *testing.T) {
 	srv1 := &Server{Config: Config{

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -203,6 +203,36 @@ func TestServerDial(t *testing.T) {
 	}
 }
 
+func TestServerChangePort(t *testing.T) {
+	// run a one-shot TCP server to handle the connection.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not setup listener: %v", err)
+	}
+	defer listener.Close()
+
+	// start the server
+	connected := make(chan *Peer)
+	remid := &newkey().PublicKey
+	srv := startTestServer(t, remid, func(p *Peer) { connected <- p })
+	defer close(connected)
+	defer srv.Stop()
+
+	srv.changeport <- enr.TCP(12819)
+	time.Sleep(10 * time.Millisecond)
+	if srv.Self().TCP() != 12819 {
+		t.Fatalf("invalid port number, want: %v, got: %v\n", 12819, srv.Self().TCP())
+		return
+	}
+
+	srv.changeport <- enr.UDP(13819)
+	time.Sleep(10 * time.Millisecond)
+	if srv.Self().UDP() != 13819 {
+		t.Fatalf("invalid port number, want: %v, got: %v\n", 13819, srv.Self().UDP())
+		return
+	}
+}
+
 // This test checks that RemovePeer disconnects the peer if it is connected.
 func TestServerRemovePeerDisconnect(t *testing.T) {
 	srv1 := &Server{Config: Config{


### PR DESCRIPTION
The purpose of that PR is efficient handling for NAT that return by allocating an alternate port if the requested port is already in use. So I changed the interface because I need to handle the port number returned from the method for AddPortMapping. I tried not to change the interface, but I couldn't solve it without using channels, and I wanted to avoid using channels because I thought it would be fatal if the caller didn't handle them properly.

The refresh process for NAT mapping is handled by the user himself. This allows free control over each calling module (bootnode, p2p.Server). In the current implementation, duplication of code doesn't seem too bad.